### PR TITLE
Live Push 2021-05-04: accessibility fixes and other improvements

### DIFF
--- a/src/helpers/addEvents.js
+++ b/src/helpers/addEvents.js
@@ -2,7 +2,7 @@ import { passiveOption } from './passiveOption.js';
 
 export function addEvents(el, obj, preventScrolling) {
   for (var prop in obj) {
-    var option = ['touchstart', 'touchmove'].indexOf(prop) >= 0 && !preventScrolling ? passiveOption : false;
+    var option = ['touchstart', 'touchmove'].indexOf(prop) >= 0 && (!preventScrolling || preventScrolling === 'auto') ? passiveOption : false;
     el.addEventListener(prop, obj[prop], option);
   }
 }

--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -237,11 +237,6 @@ export interface TinySliderSettings extends CommonOptions {
      */
     preventActionWhenRunning?: boolean
     /**
-     * Prevent page from scrolling on touchmove. If set to "auto", the slider will first check if the touch direction matches the slider axis, then decide whether prevent the page scrolling or not. If set to "force", the slider will always prevent the page scrolling.
-     * @defaultValue false
-     */
-    preventScrollOnTouch?: "auto" | "force" | false;
-    /**
      * Difine the relationship between nested sliders.
      * Make sure you run the inner slider first, otherwise the height of the inner slider container will be wrong.
      * @defaultValue false

--- a/src/tiny-slider.d.ts
+++ b/src/tiny-slider.d.ts
@@ -273,6 +273,7 @@ export interface TinySliderSettings extends CommonOptions {
 export interface TinySliderInfo {
     event: Event | {}
     cloneCount: number;
+    mode: string;
     container: HTMLElement;
     controlsContainer?: boolean;
     hasControls: boolean;

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1714,7 +1714,7 @@ export var tns = function(options) {
     var arr = getVisibleSlideRange(),
         start = arr[0] + 1,
         end = arr[1] + 1;
-    return start === end ? start + '' : start + ' to ' + end;
+    return start === end ? arr[0] : arr[0] + ' to ' + arr[1];
   }
 
   function getVisibleSlideRange (val) {
@@ -1779,8 +1779,8 @@ export var tns = function(options) {
         }
       }
 
-      start = Math.max(start, 0);
-      end = Math.min(end, slideCountNew - 1);
+      start = getAbsIndex(Math.max(start, 0)) + 1;
+      end = getAbsIndex(Math.min(end, slideCountNew - 1)) + 1;
     }
 
     return [start, end];

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion tns-visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', `<div class="tns-liveregion visually-hidden">slide <span class="current">${getLiveRegionStr()}</span> of ${slideCount}</div>`);
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==

--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==

--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -1714,7 +1714,7 @@ export var tns = function(options) {
     var arr = getVisibleSlideRange(),
         start = arr[0] + 1,
         end = arr[1] + 1;
-    return start === end ? start + '' : start + ' to ' + end;
+    return start === end ? arr[0] : arr[0] + ' to ' + arr[1];
   }
 
   function getVisibleSlideRange (val) {
@@ -1779,8 +1779,8 @@ export var tns = function(options) {
         }
       }
 
-      start = Math.max(start, 0);
-      end = Math.min(end, slideCountNew - 1);
+      start = getAbsIndex(Math.max(start, 0)) + 1;
+      end = getAbsIndex(Math.min(end, slideCountNew - 1)) + 1;
     }
 
     return [start, end];

--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion tns-visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden" aria-live="polite" aria-atomic="true">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==

--- a/src/tiny-slider.module.js
+++ b/src/tiny-slider.module.js
@@ -1002,7 +1002,7 @@ export var tns = function(options) {
     updateSlideStatus();
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<div class="tns-liveregion visually-hidden">slide <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</div>');
+    outerWrapper.insertAdjacentHTML('afterbegin', `<div class="tns-liveregion visually-hidden">slide <span class="current">${getLiveRegionStr()}</span> of ${slideCount}</div>`);
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==


### PR DESCRIPTION
## General

### Features

- Add `mode` property to `TinySliderInfo` interface (dc324488efa79230e27c53a885b9c5ffe47e8208)

### Bug Fixes

- Use passive scroll event listeners if `preventScrolling` is `auto` (9ff398b224c6bc121d315dc04fea583f90279909)
  -  Fixes PageSpeed error: _"Does not use passive listeners to improve scrolling performance"_.
- Remove aria-live attribute (d6d762087b40b3ac09366414a02b04dac98f8174)
  - Every time the current slide changed the screen reader would read it out loud, interrupting the normal content reading flow
- Slideshow pagination count (4755fb9504f9984f08a57e5465a04f394cecff9f)
- Remove duplicated property (93706c45b147c40ffaf30a707cb2c86945fabac0)

### Code Refactoring

- Update visually-hidden class (52fd1a878e6ed8735a5e077a4ab38d209e4f9f3b)

---

Closes [Justatic Issue #2366](https://github.com/justia/justatic/issues/2366)
