### PR TITLE
Live Push 2021-07-03: fix visible slide range calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/tiny-slider",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justia/tiny-slider",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "keywords": [
     "slider",

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1714,7 +1714,7 @@ export var tns = function(options) {
     var arr = getVisibleSlideRange(),
         start = getAbsIndex(arr[0]) + 1,
         end = getAbsIndex(arr[1]) + 1;
-    return start === end ? start : start + ' to ' + end;
+    return start === end ? start : `${start} to ${end}`;
   }
 
   function getVisibleSlideRange (val) {

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1712,9 +1712,9 @@ export var tns = function(options) {
 
   function getLiveRegionStr () {
     var arr = getVisibleSlideRange(),
-        start = arr[0] + 1,
-        end = arr[1] + 1;
-    return start === end ? arr[0] : arr[0] + ' to ' + arr[1];
+        start = getAbsIndex(arr[0]) + 1,
+        end = getAbsIndex(arr[1]) + 1;
+    return start === end ? start : start + ' to ' + end;
   }
 
   function getVisibleSlideRange (val) {
@@ -1779,8 +1779,8 @@ export var tns = function(options) {
         }
       }
 
-      start = getAbsIndex(Math.max(start, 0)) + 1;
-      end = getAbsIndex(Math.min(end, slideCountNew - 1)) + 1;
+      start = Math.max(start, 0);
+      end = Math.min(end, slideCountNew - 1);
     }
 
     return [start, end];


### PR DESCRIPTION
## General

### Code Refactoring

- Handle absolute indexes in the live region getter (3cfeb823d4ed21c79ce3fcc26fac77281cc4a32c)

---

### Backstory

Trying to solve [this issue](https://github.com/justia/justatic/issues/2441), I noticed the `tns-slide-active` class wasn't being applied correctly; instead of adding it to the active slides, it was added to the previous slides. This was because the [`updateSlideStatus`](https://github.com/justia/tiny-slider/blob/master/src/tiny-slider.js#L1929) function was getting the wrong `start` and `end` values (they come from the `getVisibleSlideRange` function, which I modified in PR #1).

Long story short: I reverted the fix I just mentioned and isolated that solution to the [`getLiveRegionStr`](https://github.com/justia/tiny-slider/blob/master/src/tiny-slider.js#L1713) function only.


